### PR TITLE
Don't allow nulls (undefs) to escape header parse

### DIFF
--- a/lib/SMTPProxy.pm
+++ b/lib/SMTPProxy.pm
@@ -59,8 +59,13 @@ sub setup {
                 my $headers = shift;
                 $collected{headers} = [
                     map {
-                        /^([^:]+):\s*(.+)$/s;
-                        { name => $1, value => $2 }
+                        if (/^([^:]+):\s*(.+)$/s) {
+                            { name => $1, value => $2 }
+                        }
+                        else {
+                            $self->log->warn("Could not parse header '$_'");
+                            ()
+                        }
                     } split /\r\n(?=$|\S)/, $headers
                 ];
                 $apiResult = $self->_callAPI(%collected);


### PR DESCRIPTION
This could happen if we failed to parse the header. I can't see why
this would happen; our multi-line header parsing looks to match the
RFC. Also warn if we get a header that fails to match our regex, so
we can understand what's going on.