### PR TITLE
Thirdparty perl stamp

### DIFF
--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -20,10 +20,16 @@ STAMP := touch-$(PERLID)
 #EXTRA_DIST = $(THIRDPARTY_DIST) $(wildcard bin/cpanm)
 EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
 PERL_ENV := PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) PERL_CARTON_PATH=$(THIRDPARTY_DIR)
+CARTON_ENV := $(PERL_ENV) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5
+CARTON := $(THIRDPARTY_DIR)/carton/bin/carton
 
+# carton and cpanm are order only prerequisites: having to (re)install the
+# installer says nothing about the dependency tree being out of date, and
+# letting it trigger $(CPANSNAPV) would rewrite the checked in snapshot as a
+# side effect of an ordinary build.
 all-local: $(STAMP)
 
-$(STAMP):  bin/cpanm $(CPANSNAPV)
+$(STAMP):  $(CPANSNAPV) | bin/cpanm $(CARTON)
 	$(AM_V_at)if test -d lib && test ! -f $(STAMP); then \
 	    echo "** ERROR: thirdparty/lib was built for a different perl than"; \
 	    echo "**        $(PERL)"; \
@@ -32,29 +38,32 @@ $(STAMP):  bin/cpanm $(CPANSNAPV)
 	    echo "**            cd thirdparty && $(MAKE) clean-local && $(MAKE)"; \
 	    exit 1; \
 	fi
-	$(AM_V_at)echo "** Installing Dependencies using cpanm and $(CPANSNAPV)"
+	$(AM_V_at)echo "** Installing Dependencies using carton and $(CPANSNAPV)"
 	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
-	$(PERL_ENV) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR) --installdeps ..
+	cd .. && $(CARTON_ENV) $(PERL) $(CARTON) install --deployment
 	$(AM_V_at)rm -f ../cpanfile.snapshot
 	$(AM_V_at)touch $(STAMP)
+
+$(CARTON): bin/cpanm
+	$(AM_V_at)echo "** Installing Carton"
+	$(PERL_ENV) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton
 
 bin/cpanm:
 	$(AM_V_at)mkdir -p bin
 	$(URL_CAT) https://cpanmin.us > bin/cpanm
 	$(AM_V_at)chmod 755 bin/cpanm
 
-$(CPANSNAPV): ../cpanfile
+$(CPANSNAPV): ../cpanfile | $(CARTON)
 	$(AM_V_at)echo "** Installing Dependencies using Carton install"
 	$(AM_V_at)test -f $(CPANSNAPV) && cp $(CPANSNAPV) ../cpanfile.snapshot || true
-	test -x carton/bin/carton || $(PERL_ENV) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton
-	$(PERL_ENV) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
+	cd .. && $(CARTON_ENV) $(PERL) $(CARTON) install
 	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
 	$(AM_V_at)touch $(STAMP)
 
-update: $(CPANSNAPV)
+update: $(CPANSNAPV) | $(CARTON)
 	$(AM_V_at)echo "** Updating Dependencies using Carton update"
 	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
-	$(PERL_ENV) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton update
+	cd .. && $(CARTON_ENV) $(PERL) $(CARTON) update
 	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
 
 clean-local:

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -8,18 +8,35 @@ THIRDPARTY_DIR := $(shell pwd)
 # THIRDPARTY_DIST := $(shell test -d cache && find cache -type f )
 CPANSNAPV := cpanfile-$(shell $(PERL) -MConfig -e 'my $$v =$$Config{version}; $$v =~ s/\.\d+$$//;print $$v;').snapshot
 
+# The dependency tree in lib/perl5 is only valid for the perl it was built with:
+# the XS modules are compiled for one version/architecture, while the pure perl
+# ones are not. A mixed tree is worse than an empty one, because cpanm treats an
+# already importable module as satisfied and then never installs its (arch
+# dependent) prerequisites. So stamp the tree with the identity of its perl and
+# refuse to build on top of a tree belonging to a different one.
+PERLID := $(shell $(PERL) -MConfig -e 'print "$$Config{version}-$$Config{archname}"')
+STAMP := touch-$(PERLID)
+
 #EXTRA_DIST = $(THIRDPARTY_DIST) $(wildcard bin/cpanm)
 EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
 PERL_ENV := PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) PERL_CARTON_PATH=$(THIRDPARTY_DIR)
 
-all-local: touch
+all-local: $(STAMP)
 
-touch:  bin/cpanm $(CPANSNAPV)
+$(STAMP):  bin/cpanm $(CPANSNAPV)
+	$(AM_V_at)if test -d lib && test ! -f $(STAMP); then \
+	    echo "** ERROR: thirdparty/lib was built for a different perl than"; \
+	    echo "**        $(PERL)"; \
+	    echo "**        (this tree has no $(STAMP))"; \
+	    echo "**        Discard the stale tree and build again:"; \
+	    echo "**            cd thirdparty && $(MAKE) clean-local && $(MAKE)"; \
+	    exit 1; \
+	fi
 	$(AM_V_at)echo "** Installing Dependencies using cpanm and $(CPANSNAPV)"
 	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
 	$(PERL_ENV) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR) --installdeps ..
 	$(AM_V_at)rm -f ../cpanfile.snapshot
-	$(AM_V_at)touch touch
+	$(AM_V_at)touch $(STAMP)
 
 bin/cpanm:
 	$(AM_V_at)mkdir -p bin
@@ -32,7 +49,7 @@ $(CPANSNAPV): ../cpanfile
 	test -x carton/bin/carton || $(PERL_ENV) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton
 	$(PERL_ENV) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
 	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
-	$(AM_V_at)touch touch
+	$(AM_V_at)touch $(STAMP)
 
 update: $(CPANSNAPV)
 	$(AM_V_at)echo "** Updating Dependencies using Carton update"


### PR DESCRIPTION
Some Makefile improvements suggested by Claude to ensure detection of stale thirdparty contents and also to fix pinning to cpan snapshots.

## Action required after merging

**Every existing checkout needs a one-time clean rebuild:**

```sh
cd thirdparty && make clean-local && make
```

Without it the first build after this change stops with:

```
** ERROR: thirdparty/lib was built for a different perl than
**        /path/to/perl
**        (this tree has no touch-5.32.0-x86_64-linux)
**        Discard the stale tree and build again:
**            cd thirdparty && make clean-local && make
```

That is the new guard doing its job, not a broken build: the stamp is now named after the perl version and archname, and an existing tree carries the old version-agnostic `touch` stamp instead.

`clean-local` removes `lib/ work/ cache/ carton/ build.log` and the old stamp, keeping the Makefiles, the snapshots and `bin/cpanm` — so the rebuild needs network access. Anything else that builds `thirdparty/` (Docker images, release scripts) wants the same one-time clean. No CI job is affected: `.gitlab-ci.yml` only runs gitleaks and sonar-scanner, neither of which builds the tree.

Note that after this the build installs the versions the snapshot pins rather than whatever CPAN offers that day, so the rebuilt tree may legitimately contain *older* modules than the one it replaces.
